### PR TITLE
Replace yaourt (unmaintained) with yay

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@
 [pagraphcontrol-git on AUR](https://aur.archlinux.org/packages/pagraphcontrol-git)
 
 ```bash
-yaourt pagraphcontrol-git
+yay -S pagraphcontrol-git
 ```
 
 ### Ubuntu (manual build) 


### PR DESCRIPTION
`yaourt` is no more maintained. Used `yay` instead.

**References:**
- https://archlinux.fr/yaourt-en
- https://wiki.archlinux.org/index.php/AUR_helpers