### PR TITLE
Edge case for apps that don't have icon_name

### DIFF
--- a/components/graph/index.js
+++ b/components/graph/index.js
@@ -189,9 +189,17 @@ const paoToEdge = memoize(pao => ({
 }));
 
 const getPaiIcon = memoize(pai => {
-	return null
-		|| path([ 'properties', 'application', 'icon_name' ], pai)
+	let return_var = path(['properties', 'application', 'icon_name'], pai)
 		|| path([ 'properties', 'device', 'icon_name' ], pai);
+	// Edge case for when there is no icon_name for an app
+	// Google Play Music Desktop Player is an example of this.
+	if (path(['properties', 'application', 'name'], pai) && !return_var)
+	{
+		return path(['properties', 'application', 'name'], pai).toLowerCase().replace(/ /g, '-', )
+	}
+	else {
+		return return_var
+	}
 });
 
 const s2 = size / 2;


### PR DESCRIPTION
Added an edge case for apps like Google Play Music Desktop Player that don't have an icon_name set.