### PR TITLE
Add python to ubuntu build instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ yay -S pagraphcontrol-git
 ### Ubuntu (manual build) 
 
 ```bash
-sudo apt install npm
+sudo apt install npm python
 sudo npm install -g yarn
 
 git clone https://github.com/futpib/pagraphcontrol.git


### PR DESCRIPTION
I had to install python in order for `npm install` to succeed